### PR TITLE
feat: タグ一覧をピルスタイルのレイアウトに変更

### DIFF
--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -21,7 +21,7 @@ const tags = [
       ]}
     />
     <h1 class="text-3xl font-bold mb-8 text-gray-900">タグ一覧</h1>
-    <ul class="flex flex-col gap-4 list-none p-0">
+    <ul class="flex flex-wrap gap-2 list-none p-0">
       {
         tags.map((tag) => {
           const count = articles.filter((a) =>
@@ -31,10 +31,10 @@ const tags = [
             <li>
               <a
                 href={`/tags/${tag}`}
-                class="flex items-center gap-2 text-lg text-gray-900 hover:text-blue-500 transition-colors"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-100 hover:bg-blue-100 text-gray-700 hover:text-blue-600 rounded-full text-sm transition-colors"
               >
                 <span class="font-medium">#{tag}</span>
-                <span class="text-sm text-gray-500">({count})</span>
+                <span class="text-xs text-gray-500">({count})</span>
               </a>
             </li>
           );


### PR DESCRIPTION
## 概要

タグ一覧のレイアウトを縦並びリストからピルスタイルの横並びに変更した

## 背景・モチベーション

タグ一覧を視覚的に見やすくし、スペースを効率的に使用するため

<img width="481" height="205" alt="Screenshot 2026-02-15 at 14 57 23" src="https://github.com/user-attachments/assets/5e6b9a8c-0343-4297-bf46-2cbdd78c3e2a" />

## 補足

- 日本語かつ全角/半角スペースを含むタグを設定して、リンクが正常に機能することも確認した
