### PR TITLE
feat: マークダウンのシンタックスハイライト設定

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,12 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   site: "https://noy72.com",
   integrations: [sitemap()],
+  markdown: {
+    shikiConfig: {
+      theme: "github-dark",
+      wrap: true,
+    },
+  },
   experimental: {
     csp: {
       directives: [


### PR DESCRIPTION
## 概要

<!-- このPRの目的を1-2文で説明 -->

マークダウン記事のコードブロックにシンタックスハイライトを設定した。

## 背景・モチベーション

<!-- なぜこの変更が必要なのか -->

記事内のコードブロックがハイライトされず可読性が低かった。Astro 組み込みの Shiki を活用し、見やすいコード表示を実現する。

## 実装の意図・重要なポイント

<!-- 実装で特に意図した部分や、レビュー時に理解してほしい設計判断 -->

- テーマは github-dark を採用した。見慣れているものがよさそう