### PR TITLE
feat: 記事ページに前後記事ナビゲーションを追加

### DIFF
--- a/src/components/ArticleNav.astro
+++ b/src/components/ArticleNav.astro
@@ -1,0 +1,45 @@
+---
+interface ArticleLink {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  prevArticle?: ArticleLink;
+  nextArticle?: ArticleLink;
+}
+
+const { prevArticle, nextArticle } = Astro.props;
+---
+
+{
+  (prevArticle || nextArticle) && (
+    <nav
+      aria-label="前後の記事"
+      class="mt-12 pt-8 border-t border-gray-200 grid grid-cols-2 gap-4"
+    >
+      <div>
+        {prevArticle && (
+          <a
+            href={`/articles/${prevArticle.id}`}
+            class="group block text-sm text-gray-600 hover:text-blue-500 transition-colors"
+          >
+            <span class="block text-xs text-gray-400 mb-1">前の記事</span>
+            <span class="group-hover:underline">{prevArticle.title}</span>
+          </a>
+        )}
+      </div>
+      <div class="text-right">
+        {nextArticle && (
+          <a
+            href={`/articles/${nextArticle.id}`}
+            class="group block text-sm text-gray-600 hover:text-blue-500 transition-colors"
+          >
+            <span class="block text-xs text-gray-400 mb-1">次の記事</span>
+            <span class="group-hover:underline">{nextArticle.title}</span>
+          </a>
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/src/pages/articles/[id].astro
+++ b/src/pages/articles/[id].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from "astro:content";
 import Layout from "../../layouts/Layout.astro";
 import Breadcrumb from "../../components/Breadcrumb.astro";
 import TagList from "../../components/TagList.astro";
+import ArticleNav from "../../components/ArticleNav.astro";
 import { addPublishDateToArticles } from "../../lib/article.ts";
 import { SITE_CONFIG } from "../../config/site";
 import { buildAbsoluteImageUrl, type BlogPostingSchema } from "../../lib/seo";
@@ -22,14 +23,24 @@ export async function getStaticPaths() {
   const articles = await getCollection("articles", ({ data }) => {
     return import.meta.env.PROD ? !data.draft : true;
   });
-  const articlesWithDate = addPublishDateToArticles(articles);
-  return articlesWithDate.map((article) => ({
-    params: { id: article.id },
-    props: article,
-  }));
+  const sorted = addPublishDateToArticles(articles).toSorted(
+    (a, b) => a.publishDate.getTime() - b.publishDate.getTime(),
+  );
+  return sorted.map((article, index) => {
+    const prev = sorted[index - 1];
+    const next = sorted[index + 1];
+    return {
+      params: { id: article.id },
+      props: {
+        ...article,
+        prevArticle: prev ? { id: prev.id, title: prev.data.title } : undefined,
+        nextArticle: next ? { id: next.id, title: next.data.title } : undefined,
+      },
+    };
+  });
 }
 
-const article = Astro.props;
+const { prevArticle, nextArticle, ...article } = Astro.props;
 const { Content } = await render(article);
 
 const description =
@@ -91,4 +102,5 @@ const jsonLd: BlogPostingSchema = {
       <Content />
     </div>
   </article>
+  <ArticleNav prevArticle={prevArticle} nextArticle={nextArticle} />
 </Layout>


### PR DESCRIPTION
## 概要

記事詳細ページに「前の記事」「次の記事」へのナビゲーションリンクを追加した。

## 背景・モチベーション

記事を読み終えた後に他の記事へ遷移する導線がなく、回遊性が低かった。前後の記事へのリンクを設けることで、読者が自然に他の記事を発見できるようにした。
