### PR TITLE
feat: ブログカードremarkプラグインを追加

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,13 +6,14 @@ import tailwindcss from "@tailwindcss/vite";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import remarkImgurImage from "./src/plugins/remark-imgur-image.ts";
+import remarkBlogCard from "./src/plugins/remark-blog-card.ts";
 
 // https://astro.build/config
 export default defineConfig({
   site: "https://noy72.com",
   integrations: [sitemap()],
   markdown: {
-    remarkPlugins: [remarkMath, remarkImgurImage],
+    remarkPlugins: [remarkMath, remarkImgurImage, remarkBlogCard],
     rehypePlugins: [rehypeKatex],
     shikiConfig: {
       theme: "github-dark",
@@ -25,6 +26,7 @@ export default defineConfig({
         "default-src 'self'",
         "img-src 'self' https://i.imgur.com https://placehold.co",
         "font-src 'self' https://fonts.gstatic.com https://cdn.jsdelivr.net",
+        "frame-src 'self' https://hatenablog-parts.com",
         "object-src 'none'",
         "base-uri 'self'",
         "upgrade-insecure-requests",

--- a/src/plugins/remark-blog-card.test.ts
+++ b/src/plugins/remark-blog-card.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkStringify from "remark-stringify";
+import remarkBlogCard from "./remark-blog-card";
+
+function process(markdown: string): string {
+  const result = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkBlogCard)
+    .use(remarkStringify)
+    .processSync(markdown);
+  return String(result);
+}
+
+describe("remarkBlogCard", () => {
+  it("|embed付きリンクをiframeに変換する", () => {
+    const output = process("[example](https://example.com|embed)\n");
+    expect(output).toContain("<iframe");
+    expect(output).toContain(
+      'src="https://hatenablog-parts.com/embed?url=https://example.com"',
+    );
+  });
+
+  it("iframeにhatenablogcardクラスを付与する", () => {
+    const output = process("[example](https://example.com|embed)\n");
+    expect(output).toContain('class="hatenablogcard"');
+  });
+
+  it("iframeにスタイルを付与する", () => {
+    const output = process("[example](https://example.com|embed)\n");
+    expect(output).toContain(
+      'style="width:100%; height:155px; max-width:640px;"',
+    );
+  });
+
+  it("iframeにframeborder=0とscrolling=noを付与する", () => {
+    const output = process("[example](https://example.com|embed)\n");
+    expect(output).toContain('frameborder="0"');
+    expect(output).toContain('scrolling="no"');
+  });
+
+  it("|embedなしのリンクは変換しない", () => {
+    const output = process("[example](https://example.com)\n");
+    expect(output).not.toContain("<iframe");
+    expect(output).toContain("[example](https://example.com)");
+  });
+
+  it("通常のテキストは変換しない", () => {
+    const output = process("これは普通のテキストです\n");
+    expect(output).not.toContain("<iframe");
+    expect(output).toContain("これは普通のテキストです");
+  });
+
+  it("インライン中の|embedリンクも変換する", () => {
+    const output = process(
+      "テキスト [example](https://example.com|embed) テキスト\n",
+    );
+    expect(output).toContain("<iframe");
+  });
+
+  it("連続する|embedリンクはそれぞれ変換される", () => {
+    const input = [
+      "[a](https://example.com/a|embed)",
+      "",
+      "[b](https://example.com/b|embed)",
+      "",
+    ].join("\n");
+    const output = process(input);
+    const iframeCount = (output.match(/<iframe/g) || []).length;
+    expect(iframeCount).toBe(2);
+  });
+
+  it("URLのクエリパラメータを保持する", () => {
+    const output = process(
+      "[example](https://example.com/path?key=value|embed)\n",
+    );
+    expect(output).toContain("url=https://example.com/path?key=value");
+  });
+
+  it("|embed以外のサフィックスは変換しない", () => {
+    const output = process("[example](https://example.com|other)\n");
+    expect(output).not.toContain("<iframe");
+  });
+});

--- a/src/plugins/remark-blog-card.ts
+++ b/src/plugins/remark-blog-card.ts
@@ -1,0 +1,38 @@
+import type { Root, Link, Html, Parent } from "mdast";
+import type { Plugin } from "unified";
+
+const EMBED_SUFFIX = "|embed";
+
+function buildIframe(url: string): Html {
+  return {
+    type: "html",
+    value: `<iframe class="hatenablogcard" style="width:100%; height:155px; max-width:640px;" src="https://hatenablog-parts.com/embed?url=${url}" width="300" height="150" frameborder="0" scrolling="no"></iframe>`,
+  };
+}
+
+function transformLinks(parent: Parent): void {
+  for (let i = 0; i < parent.children.length; i++) {
+    const node = parent.children[i];
+
+    if (node.type === "link") {
+      const link = node as Link;
+      if (!link.url.endsWith(EMBED_SUFFIX)) continue;
+
+      const url = link.url.slice(0, -EMBED_SUFFIX.length);
+      parent.children[i] = buildIframe(url) as (typeof parent.children)[number];
+      continue;
+    }
+
+    if ("children" in node) {
+      transformLinks(node as Parent);
+    }
+  }
+}
+
+const remarkBlogCard: Plugin<[], Root> = () => {
+  return (tree: Root) => {
+    transformLinks(tree);
+  };
+};
+
+export default remarkBlogCard;


### PR DESCRIPTION
https://github.com/noy72/noy72-blog/issues/26

## 概要

Markdown 内のリンクをはてなブログカード形式の iframe に変換する remark プラグインを追加した。

## 背景・モチベーション

記事内で外部リンクをブログカード形式で埋め込みたい場合、手動で iframe を書く必要があった。Markdown の記法だけで埋め込みを表現できるようにするため、プラグインを実装した。

## 実装の意図・重要なポイント

`|embed` サフィックスを URL に付与することで埋め込みを指定する記法にした。
CSP に `frame-src` を追加して hatenablog-parts.com からの iframe 読み込みを許可している。