### PR TITLE
feat: タグを記事数が多い順にソート

### DIFF
--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -7,13 +7,13 @@ const articles = await getCollection("articles", ({ data }) => {
   return import.meta.env.PROD ? !data.draft : true;
 });
 
-const tags = Object.entries(
-  articles
-    .flatMap((a) => a.data.tags || [])
-    .reduce<
-      Record<string, number>
-    >((acc, tag) => ({ ...acc, [tag]: (acc[tag] || 0) + 1 }), {}),
-).toSorted(
+const tagCounts = articles
+  .flatMap((a) => a.data.tags || [])
+  .reduce<
+    Record<string, number>
+  >((acc, tag) => ({ ...acc, [tag]: (acc[tag] || 0) + 1 }), {});
+
+const tags = Object.entries(tagCounts).toSorted(
   ([tagA, countA], [tagB, countB]) =>
     countB - countA || tagA.localeCompare(tagB),
 );


### PR DESCRIPTION
## 概要

タグ一覧ページのソート順を、記事数降順・タグ名昇順に変更した。

## 背景・モチベーション

タグが多くなると一覧が見にくくなるため、記事数が多いタグを先に表示したい。記事数が同じ場合はタグ名のアルファベット順で一貫した表示順を保つ。

## 実装の意図・重要なポイント

タグと記事数を同時に計算するため、`reduce` でタグごとのカウントを集計した後に `Object.entries` で配列に変換し、複合ソートを適用した。これにより、テンプレート内でのカウント再計算（O(n×m) の重複処理）を排除した。

Closes #31