### PR TITLE
style: 記事ページ末尾のセクション間スペースを縮小

### DIFF
--- a/src/components/ArticleNav.astro
+++ b/src/components/ArticleNav.astro
@@ -16,7 +16,7 @@ const { prevArticle, nextArticle } = Astro.props;
   (prevArticle || nextArticle) && (
     <nav
       aria-label="前後の記事"
-      class="container-main mt-12 pt-8 border-t border-gray-200 grid grid-cols-2 gap-4"
+      class="container-main mt-0 pt-4 border-t border-gray-200 grid grid-cols-2 gap-4"
     >
       <div>
         {prevArticle && (

--- a/src/components/RelatedArticles.astro
+++ b/src/components/RelatedArticles.astro
@@ -10,7 +10,7 @@ const { articles } = Astro.props;
 
 {
   articles.length > 0 && (
-    <aside class="container-main mt-12">
+    <aside class="container-main mt-6">
       <h2 class="text-xl font-semibold text-gray-900 mb-4">関連記事</h2>
       <ul class="space-y-3">
         {articles.map((article) => (


### PR DESCRIPTION
## 概要

記事ページ末尾の関連記事・前後記事ナビのスペーシングを縮小した。

## 背景・モチベーション

記事ページ下部の空白が広くスクロールが面倒だった。`container-main` の `py-12` に加え、各セクションの `mt-12` が積み重なり、セクション間の視覚的な余白が過剰になっていた。

## 実装の意図・重要なポイント

- `RelatedArticles`: `mt-12` → `mt-6` に縮小
- `ArticleNav`: `mt-12 pt-8` → `mt-0 pt-4` に縮小。`container-main` の `py-12` が前セクション末尾の下部パディング (48px) を担うため、`mt-0` でもセクション間の間隔は確保される

https://github.com/noy72/noy72-blog/issues/27