### PR TITLE
ci: 記事ファイルへの Prettier 自動フォーマットワークフローを追加

### DIFF
--- a/.github/workflows/format-articles.yaml
+++ b/.github/workflows/format-articles.yaml
@@ -1,0 +1,44 @@
+name: Format Articles
+
+on:
+  push:
+    paths:
+      - "src/data/articles/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: Format Articles
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".tool-versions"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Format
+        run: pnpm exec prettier --write "src/data/articles/**"
+
+      - name: Commit formatted files
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: apply Prettier formatting"
+          file_pattern: "src/data/articles/**"


### PR DESCRIPTION
## 概要

記事ファイル (`src/data/articles/**`) が push されたとき、Prettier を自動適用してコミットし返す GitHub Actions ワークフローを追加した。

## 背景・モチベーション

記事を追加・編集する際にフォーマットを意識しなくても CI が自動修正してくれる仕組みが欲しかった。現状は format:check がエラーになったとき手動で修正が必要で、今回のような CI 失敗が発生しやすい。