### PR TITLE
feat: 引用部分のテキスト色を薄くして差別化

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,6 +42,7 @@ body {
 
 .prose blockquote {
   font-style: normal;
+  font-weight: 400;
 }
 
 .prose a {


### PR DESCRIPTION
## 概要

blockquote のテキスト色を薄いグレーに変更し、通常テキストと視覚的に差別化した。

## 背景・モチベーション

引用部分が通常テキストと見た目が似ており、引用であることが一目でわかりにくかった。

## 実装の意図・重要なポイント

`--tw-prose-quotes` を `gray.900` から `gray.500` に変更することで、通常テキスト（`gray.700`）より明確に薄い色になる。また、`@tailwindcss/typography` プラグインはデフォルトで blockquote にイタリックを適用するため、`font-style: normal` で上書きした。

close https://github.com/noy72/noy72-blog/issues/38