### PR TITLE
feat: About ページのコンテンツを充実させる

### DIFF
--- a/src/data/about/about.md
+++ b/src/data/about/about.md
@@ -1,9 +1,37 @@
-このブログについての説明が入ります。
+## noy72
 
-## プロフィール
+web アプリケーションエンジニア。エンジニアリングマネージャーになりつつある。
+開発プロセスやチームの改善に加えてピープルマネジメントも担当し始めた。
 
-ここにプロフィールを記載します。
+[Feed](/rss.xml) / [X(Twitter)](https://twitter.com/noynote)
+
+### 略歴
+
+- 2015年4月 - 立命館大学情報理工学部入学
+- 2019年4月 - 立命館大学情報理工学部卒業、立命館大学情報理工学研究科入学
+- 2021年4月 - 立命館大学情報理工学研究科卒業、株式会社はてな入社
+
+### 活動
+
+#### 資格
+
+- 2023年3月 - Certified ScrumMaster
+- 2023年8月 - Professional Cloud Developer
+- 2024年3月 - Professional Cloud Architect
+
+#### 登壇
+
+- 2019年11月 - ソフトウェア工学の基礎研究会(FOSE)「テストケースが自動バグ修正に与える影響の調査」
+- 2022年1月 - Hatena Engineer Seminar #18「ビジネスプラットフォームチームで始めた『筋トレ』施策について」
+- 2023年12月 - 【オフライン開催】Kyoto Tech Talk #3「開発合宿の裏側 - Web アプリケーションを素早く作る」
+- 2024年10月 - はてな 生成AI×新規事業 の挑戦「新規事業×生成 AI の不確実性を乗り越える開発プロセス」
 
 ## このサイトについて
 
-このサイトは Astro + TypeScript + Tailwind CSS で構築されています。
+本サイトのいくつかのページでは、Google社のサービスであるGoogle Analyticsを利用しています。Google Analyticsは、本サイトが発行するクッキーを利用して、ユーザの訪問履歴を収集します。
+ユーザは、本サイトを利用することでcookieの使用に許可を与えたものとみなします。
+Google Analyticsオプトアウトアドオンを利用することで、Google Analyticsによる情報の収集を停止することができます。
+
+- [Terms of Service | Google Analytics – Google](https://marketingplatform.google.com/about/analytics/terms/jp/)
+- [プライバシー ポリシー – ポリシーと規約 – Google](https://policies.google.com/privacy?hl=ja)
+- [Google アナリティクス オプトアウト アドオンのダウンロード ページ](https://tools.google.com/dlpage/gaoptout?hl=ja)

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -16,7 +16,7 @@ const { Content } = await render(aboutEntry);
         { label: "About", href: "/about" },
       ]}
     />
-    <h1 class="text-3xl font-semibold mb-8 text-gray-900">About</h1>
+    <h1 class="text-3xl font-semibold mb-8 text-gray-900">About me</h1>
     <div class="prose prose-slate max-w-none">
       <Content />
     </div>


### PR DESCRIPTION
## 概要

About ページに実際のプロフィール情報と略歴・活動履歴を追加した。

## 背景・モチベーション

About ページがプレースホルダーのままであったため、実際のコンテンツに差し替える必要があった。

## 実装の意図・重要なポイント

- ページタイトルを「About」から「About me」に変更し、個人ページとしての意図を明確にした